### PR TITLE
Model Fish does not have a user_id column

### DIFF
--- a/app/services/seed_service.rb
+++ b/app/services/seed_service.rb
@@ -9,7 +9,6 @@ class SeedService
     Fish.delete_all
     Course.delete_all
     Course::Link.delete_all
-    Fish.delete_all
     TeamMembership.delete_all
     Team.delete_all
     Comment.delete_all

--- a/db/migrate/20220729223019_add_user_id_to_fish.rb
+++ b/db/migrate/20220729223019_add_user_id_to_fish.rb
@@ -1,0 +1,5 @@
+class AddUserIdToFish < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :fish, :user, null: true, foreign_key: true
+  end
+end


### PR DESCRIPTION
The Fish model serves as a good test for model names like Aircraft / Sheep / Moose where the plural name is exactly the same as the singular.  In the dummy app for Avo there is a migration to add the `user_id` column to the fish table, but so far that has been missing in this demo.