### PR TITLE
Status tags filter: label/value suggestions with emoji labels

### DIFF
--- a/app/avo/resources/project.rb
+++ b/app/avo/resources/project.rb
@@ -36,7 +36,9 @@ class Avo::Resources::Project < Avo::BaseResource
       include_blank: false,
       filterable: true
     field :stage, as: :badge, options: {info: ["Discovery", "Idea"], success: "Done", warning: "On hold", danger: "Cancelled"}, summarizable: true
-    # String-column multi-select via tags (where status IN (...))
+    # String-column multi-select via tags (where status IN (...)).
+    # Suggestions carry a display label and a technical value, like a select
+    # field: the UI shows the label, the query receives the value.
     field :status,
       as: :status,
       failed_when: [:closed, :rejected, :failed],
@@ -48,7 +50,18 @@ class Avo::Resources::Project < Avo::BaseResource
         label: "Status",
         icon: "heroicons/outline/signal",
         conditions: {},
-        suggestions: %w[closed rejected failed loading running waiting done finalized archived finished],
+        suggestions: [
+          {value: "closed", label: "🔒 Closed"},
+          {value: "rejected", label: "🚫 Rejected"},
+          {value: "failed", label: "❌ Failed"},
+          {value: "loading", label: "🔄 Loading"},
+          {value: "running", label: "🏃 Running"},
+          {value: "waiting", label: "⏳ Waiting"},
+          {value: "done", label: "✅ Done"},
+          {value: "finalized", label: "✍️ Finalized"},
+          {value: "archived", label: "🗄️ Archived"},
+          {value: "finished", label: "🏁 Finished"}
+        ],
         humanized_condition: -> {
           (filter.value.to_s.split(",").count > 1) ? "are any of" : "is"
         },


### PR DESCRIPTION
## What

Converts the Project `status` tags dynamic filter suggestions from plain strings to `{value:, label:}` hashes, with a themed emoji on each label:

```ruby
suggestions: [
  {value: "waiting", label: "⏳ Waiting"},
  {value: "running", label: "🏃 Running"},
  {value: "closed",  label: "🔒 Closed"},
  # ...
],
```

## Why

Demonstrates select-like behavior on a tags-type dynamic filter: the UI (suggestions dropdown, chips, applied-filter pill) shows display labels while the query receives the technical lowercase values — the use case raised on Discord where a user assumed tags filters couldn't have separate display/technical values.

## Verified in the browser

- Dropdown and chips render the emoji labels; each item's `value` attr stays the technical string.
- Applied pill reads `Status are any of "⏳ Waiting, 🏃 Running"`.
- URL carries only technical values (`filters[status][array_is][]=waiting,running`) and the index returns exactly the waiting/running projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)