### PR TITLE
Add lexxy field (with media library) to Post

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,6 +143,7 @@ gem "db_config", "0.1.10"
 gem "view_component"
 
 gem "avo-rhino_field"
+gem "avo-lexxy_field"
 
 # gem "avo", path: "/Users/adrian/work/avocado/gems/avo"
 # gem "avo", path: "../gems/avo"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,9 @@ GEM
       zeitwerk (>= 2.6.12)
     avo-icons (0.1.6)
       inline_svg
+    avo-lexxy_field (0.1.3)
+      avo (>= 4.0)
+      lexxy (>= 0.9)
     avo-money_field (0.0.6)
       money-rails (~> 1.12)
     avo-rhino_field (4.0.4)
@@ -334,6 +337,8 @@ GEM
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.20.0)
+    lexxy (0.9.28)
+      rails (>= 8.0.2)
     logger (1.7.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
@@ -578,6 +583,7 @@ DEPENDENCIES
   avo-http_resource!
   avo-intelligence!
   avo-kanban!
+  avo-lexxy_field
   avo-menu!
   avo-money_field
   avo-nested!

--- a/app/avo/resources/post.rb
+++ b/app/avo/resources/post.rb
@@ -54,6 +54,7 @@ class Avo::Resources::Post < Avo::BaseResource
     field :name, as: :text, required: true, sortable: true
     field :body,
       as: :rhino
+    field :lexxy_body, as: :lexxy, name: "Lexxy body", always_show: true
     field :tags,
       as: :tags,
       # readonly: true,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -18,6 +18,10 @@ class Post < ApplicationRecord
 
   validates :name, presence: true
 
+  # Action Text backing for the `:lexxy` field — attachments (and the media
+  # library picker) need a rich text attribute, not a plain column.
+  has_rich_text :lexxy_body
+
   has_one_attached :cover_photo
   has_one_attached :audio
   has_many_attached :trix_attachments

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,8 @@ module Avodemo7
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.active_storage.variant_processor = :mini_magick
+    # Keep Lexxy inside Avo only; the app's `rich_text_area` helpers stay on Trix.
+    config.lexxy.override_action_text_defaults = false
     config.middleware.use AccountMiddleware
   end
 end

--- a/db/migrate/20260806103259_create_action_text_tables.action_text.rb
+++ b/db/migrate/20260806103259_create_action_text_tables.action_text.rb
@@ -1,0 +1,26 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :action_text_rich_texts, id: primary_key_type do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_31_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_06_103259) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false


### PR DESCRIPTION
Adds the [`lexxy` field](https://docs.avohq.io/4.0/fields/lexxy.html) to the demo, on `Post` — a second rich-text field next to the existing `:rhino` body, so the two editors sit side by side.

### Why Action Text had to come along

The app had no `action_text_rich_texts` table — `rhino` and `trix` here both run on plain `text` columns. Lexxy disables attachments on plain columns (they'd orphan blobs), and the media library button is hidden whenever attachments are disabled. So `has_rich_text :lexxy_body` it is.

Copied the engine migration only (`rails action_text:install:migrations`) — no importmap/JS install, since Avo loads its own editor bundle.

### Media library

Already enabled in `config/initializers/avo.rb`, so nothing to wire up beyond the above. The toolbar gets the picker button; choosing an asset inserts it as an Action Text attachment.

### Changes

- `Gemfile` — `gem "avo-lexxy_field"` (0.1.3, pulls `lexxy` 0.9.28)
- `db/migrate/*_create_action_text_tables.action_text.rb` + `db/schema.rb`
- `app/models/post.rb` — `has_rich_text :lexxy_body`
- `app/avo/resources/post.rb` — `field :lexxy_body, as: :lexxy, always_show: true`
- `config/application.rb` — `config.lexxy.override_action_text_defaults = false`, so the lexxy gem doesn't take over `form.rich_text_area` app-wide

### Verified

On `/avo/resources/posts/new`: editor renders, media library button opens the modal with existing blobs, picking one inserts it into the editor. Round-tripped through the DB — the attachment persists and resolves back to an `ActiveStorage::Blob`.

Deploy needs `rails db:migrate`.