### PR TITLE
fix: build HTTP user create/update requests against the resource endpoint

### DIFF
--- a/app/controllers/avo/http_users_controller.rb
+++ b/app/controllers/avo/http_users_controller.rb
@@ -2,28 +2,50 @@
 # More information on https://docs.avohq.io/4.0/controllers.html
 class Avo::HttpUsersController < Avo::Core::Controllers::Http
   def save_record
-    if action_name == "create"
-      response = resource.client.class.post("", body: {user: @record.as_json.merge(password: SecureRandom.hex(10))})
-    else
-      response = resource.client.class.patch("/#{@record.id}", body: {user: @record.as_json.merge(password: SecureRandom.hex(10))})
-    end
+    response = api_response
+    payload = response.parsed_response
+    payload = {} unless payload.is_a?(Hash)
 
-    parsed_response = response.parsed_response
-
-    if parsed_response["record"].present?
-      @record.id = parsed_response["record"]["id"]
+    if payload["record"].present?
+      @record.id = payload["record"]["id"]
       return true
-    else
-      parsed_response["errors"].each do |attribute, message|
-        message.each do |error|
-          @record.errors.add(attribute, error)
-        end
-      end
-      return false
     end
+
+    if payload["errors"].present?
+      payload["errors"].each do |attribute, messages|
+        Array.wrap(messages).each { |message| @record.errors.add(attribute, message) }
+      end
+    else
+      # 401/404/5xx carry no `errors` payload — without this the form would fail
+      # silently, or blow up iterating nil.
+      @record.errors.add(:base, "The API responded with #{response.code}.")
+    end
+
+    false
   end
 
   def create_success_action
     redirect_to avo.resources_http_user_path(@record)
+  end
+
+  private
+
+  # The API nests the payload under `user` and needs a password on create, so the
+  # request is built here instead of going through the client's create/update.
+  #
+  # It must request the resource's own (absolute) endpoint: a relative path has no
+  # host to connect to, and Net::HTTP fails on the nil address well after the form
+  # was submitted (AVO-1745).
+  def api_response
+    endpoint = resource.endpoint
+    headers = Avo::ExecutionContext.new(target: resource.headers).handle
+
+    if action_name == "create"
+      body = {user: @record.as_json.merge(password: SecureRandom.hex(10))}
+
+      HTTParty.post(endpoint, body: body, headers: headers)
+    else
+      HTTParty.patch("#{endpoint}/#{@record.id}", body: {user: @record.as_json}, headers: headers)
+    end
   end
 end

--- a/app/controllers/avo/http_users_controller.rb
+++ b/app/controllers/avo/http_users_controller.rb
@@ -36,6 +36,8 @@ class Avo::HttpUsersController < Avo::Core::Controllers::Http
   # It must request the resource's own (absolute) endpoint: a relative path has no
   # host to connect to, and Net::HTTP fails on the nil address well after the form
   # was submitted (AVO-1745).
+  # `timeout` because HTTParty has no default one and the endpoint is this same
+  # app -- an unbounded request would hold the web worker for as long as it hangs.
   def api_response
     endpoint = resource.endpoint
     headers = Avo::ExecutionContext.new(target: resource.headers).handle
@@ -43,9 +45,9 @@ class Avo::HttpUsersController < Avo::Core::Controllers::Http
     if action_name == "create"
       body = {user: @record.as_json.merge(password: SecureRandom.hex(10))}
 
-      HTTParty.post(endpoint, body: body, headers: headers)
+      HTTParty.post(endpoint, body: body, headers: headers, timeout: 10)
     else
-      HTTParty.patch("#{endpoint}/#{@record.id}", body: {user: @record.as_json}, headers: headers)
+      HTTParty.patch("#{endpoint}/#{@record.id}", body: {user: @record.as_json}, headers: headers, timeout: 10)
     end
   end
 end


### PR DESCRIPTION
Fixes [AVO-1745](https://linear.app/avo-hq/issue/AVO-1745) — the BugSnag error where creating an HTTP user raised `undefined method 'include?' for nil` from Net::HTTP.

## The bug

`Avo::HttpUsersController#save_record` requested a **relative** path off the HTTParty class:

```ruby
resource.client.class.post("", body: ...)
resource.client.class.patch("/#{@record.id}", body: ...)
```

`Avo::HttpResource::Client` never sets a `base_uri`, so HTTParty handed Net::HTTP a URL with no host. Net::HTTP then failed mid-connect on the nil address — the `include?` on nil in the report. Create and update could never succeed; the address was missing on every attempt, not intermittently.

## The fix

Build the request from the resource's own absolute `endpoint`, and send the headers the resource configures (the basic-auth credential from the Settings → Integrations cookie) — the old call sent none, so even with a correct URL the API would have rejected it once authentication is switched back on.

Two smaller things in the same method:

- A response with no `errors` key (401/404/5xx) previously either reported success or raised iterating `nil`. It now adds the status to `:base` so the form says something.
- The random password is sent on **create** only. It was also sent on update, quietly rotating the user's password on every edit.

## Verification

This app has no test suite (only the generated `connection_test.rb`), so this is verified by reading the failing path plus a matching test on the gem side: `avo-http_resource` now refuses a host-less endpoint before the request leaves, with the case reproduced first — see the companion PR in `avo-hq/workspace`.